### PR TITLE
Reflect 1.0.0 rc1 and  Replace obsolete function in Webform 6.0 for D…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,9 @@
     "require": {
         "ml/json-ld": "^1.2",
         "mtdowling/jmespath.php":"^2.5",
-        "strawberryfield/strawberryfield":"dev-8.x-1.0-beta3",
-        "strawberryfield/format_strawberryfield":"dev-8.x-1.0-beta3",
-        "drupal/webform": "^5.19",
+        "strawberryfield/strawberryfield":"dev-1.0.0-RC1",
+        "strawberryfield/format_strawberryfield":"dev-1.0.0-RC1",
+        "drupal/webform": "^5.19 || ^6.0",
         "drupal/webform_views": "^5.0"
     }
 }

--- a/src/Plugin/WebformElement/WebformLoC.php
+++ b/src/Plugin/WebformElement/WebformLoC.php
@@ -79,9 +79,28 @@ class WebformLoC extends WebformCompositeBase {
     }
 
     $rdftype = $rdftype ?: $this->getDefaultProperty($rdftype);
-
-    $element['#element']['#webform_composite_elements']['label']["#autocomplete_route_parameters"] =
-      ['auth_type' => 'loc', 'vocab' => $vocab, 'rdftype'=> $rdftype ,'count' => 10];
+    // This seems to have been an old Webform module variation
+    // Keeping it here until sure its not gone for good
+    if (isset($element['#element']['#webform_composite_elements']['label'])) {
+      $element['#element']['#webform_composite_elements']['label']["#autocomplete_route_parameters"] =
+        [
+          'auth_type' => 'loc',
+          'vocab' => $vocab,
+          'rdftype' => $rdftype,
+          'count' => 10
+        ];
+    }
+    // For some reason i can not understand, when multiples are using
+    // Tables, the #webform_composite_elements -> 'label' is not used...
+    if (isset($element["#multiple__header"]) && $element["#multiple__header"] == true) {
+      $element['#element']['label']["#autocomplete_route_parameters"] =
+        [
+          'auth_type' => 'loc',
+          'vocab' => $vocab,
+          'rdftype' => $rdftype,
+          'count' => 10
+        ];
+    }
   }
 
 

--- a/src/Plugin/WebformElement/WebformNominatim.php
+++ b/src/Plugin/WebformElement/WebformNominatim.php
@@ -38,7 +38,7 @@ class WebformNominatim extends WebformLocationBase {
         'geolocation' => FALSE,
         'hidden' => FALSE,
         'map' => FALSE,
-      ] + $this->getDefaultBaseProperties();
+      ] + $this->defineDefaultBaseProperties();
   }
 
   /**


### PR DESCRIPTION
…rupal 9  (#65)

* Beta3 Regression fix -- Multiple with Table headers

While doing some new code on 1.0.0RC1 i found this annoying issue in beta3. Just in case, for people running beta3, i prefer to fix this
basically if you are using LoC rdftypes (e.g CorporateName) and also multiple and also Table headers, for some reason out of my understanding webform decides to not reuse values set by the composite builder method inside the element. This gets over the issue. Same change under a different commit is already applied to ISSUE-60 branch that will go into 1.0.0-RC1. Feels a bit messy but reason is ISSUE-60 also contains dependencies on newer code that we can not put here as a regression fix.

* Align to 1.0.0-RC1

* Replace obsolete function in Drupal 9

Co-authored-by: Diego Pino Navarro <DiegoPino@users.noreply.github.com>