### PR TITLE
Issue 102: Add EDTF validation for free form date field (#104)

### DIFF
--- a/src/Element/WebformMetadataDate.php
+++ b/src/Element/WebformMetadataDate.php
@@ -4,21 +4,17 @@ namespace Drupal\webform_strawberryfield\Element;
 
 use Drupal\Core\Render\Element\FormElement;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\webform\Utility\WebformElementHelper;
-use Drupal\webform\Element\WebformCompositeFormElementTrait;
 use Drupal\Component\Utility\NestedArray;
+use EDTF\EdtfFactory;
 
 /**
- * Provides a webform element requiring users to double-element and confirm an email address.
+ * Provides a webform element for Metadata aware Dates.
  *
- * Formats as a pair of email addresses fields, which do not validate unless
- * the two entered email addresses match.
+ * Allows Single Point, Ranges, Free Form as either unformatted or EDTF.
  *
  * @FormElement("webform_metadata_date")
  */
 class WebformMetadataDate extends FormElement {
-
-  use WebformCompositeFormElementTrait;
 
   /**
    * {@inheritdoc}
@@ -28,10 +24,7 @@ class WebformMetadataDate extends FormElement {
     $class = get_class($this);
     $info['#input'] = TRUE;
     $info['#size'] = 60;
-    $info['#pre_render'] = [
-        [$class, 'preRenderWebformCompositeFormElement'],
-      ];
-     $info['#required'] = FALSE;
+    $info['#required'] = FALSE;
       // Add validate callback.
     $info['#element_validate'] = [[$class, 'validateMetadataDates']];
     $info['#process'] = [[$class, 'processWebformMetadataDate']];
@@ -61,10 +54,8 @@ class WebformMetadataDate extends FormElement {
    * Expand date element into multiple inputs. .
    */
   public static function processWebformMetadataDate(&$element, FormStateInterface $form_state, &$complete_form) {
-
     $element['#tree'] = TRUE;
     $name_prefix = $element['#name'];
-
     // Get shared properties.
     $shared_properties = [
       '#size',
@@ -79,7 +70,7 @@ class WebformMetadataDate extends FormElement {
     // Also distribute general Attributes to each input
     $element_shared_properties = [
         '#type' => 'date',
-        '#webform_element' => TRUE,
+        //'#webform_element' => TRUE,
       ] + array_intersect_key($element, array_combine($shared_properties, $shared_properties));
     // Copy wrapper attributes to shared element attributes.
     if (isset($element['#wrapper_attributes'])
@@ -91,13 +82,13 @@ class WebformMetadataDate extends FormElement {
         }
       }
     }
-
     $date_from_properties = [
       '#title',
-      '#description',
+      '#description_display',
       '#help_title',
-      '#help',
       '#help_display',
+      '#title_display',
+      '#label_display',
     ];
 
     $date_from_value = NULL;
@@ -146,6 +137,14 @@ class WebformMetadataDate extends FormElement {
       }
     }
 
+    if(!empty($element['#edtf_validateme'])) {
+      $date_free_msg = t('EDTF formatted date');
+      $date_free_title = t('EDTF date');
+    }
+    else {
+      $date_free_msg = t('Free form date (e.g Circa Summer of 1977)');
+      $date_free_title = t('Free form date');
+    }
     // The date formatting/options
     $element['date_type'] = [
       '#type' => 'radios',
@@ -154,7 +153,7 @@ class WebformMetadataDate extends FormElement {
       '#options' => [
         'date_point' => t('Date'),
         'date_range' => t('Date Range'),
-        'date_free' => t('Free form Date (e.g Circa Spring of 1977)'),
+        'date_free' => $date_free_msg,
       ]
     ];
     /* Just and idea? Since we need modal labels.
@@ -209,18 +208,13 @@ class WebformMetadataDate extends FormElement {
     $element['date_from'] = $element_shared_properties + array_intersect_key($element, array_combine($date_from_properties, $date_from_properties));
     $element['date_from']['#attributes']['class'][] = 'webform-date-from';
     $element['date_from']['#default_value'] = $date_from_value;
-    $element['date_from']['#error_no_message'] = TRUE;
-
     $element['date_to'] = $element_shared_properties;
 
     $element['date_to']['#attributes']['class'][] = 'webform-date-to';
     $element['date_to']['#default_value'] = $date_to_value;
-    $element['date_to']['#error_no_message'] = TRUE;
-
 
     $element['date_to']['#title'] = t('End Date (ISO 8601)');
     $element['date_from']['#title'] = t('Start or Point Date (ISO 8601)');
-
     // pass #date attributes to sub elements before calling ::buildElement
 
     $element['date_to']['#date_date_format'] = $element['#date_date_format'];
@@ -260,10 +254,9 @@ class WebformMetadataDate extends FormElement {
     $element['date_from']['#datepicker'] = TRUE;
     $element['date_to']['#datepicker'] = TRUE;
 
-    $element['date_free']['#title'] = t('Free form Date');
+    $element['date_free']['#title'] = $date_free_title;
     $element['date_free']['#attributes']['class'][] = 'webform-date-free';
     $element['date_free']['#default_value'] = $date_free_value;
-    $element['date_free']['#error_no_message'] = TRUE;
     $element['date_free']['#type'] = 'textfield';
     $element['date_free']['#webform_element'] = TRUE;
     $element['date_free']['#size'] =  isset($element['#size']) ? $element['#size'] : '60';
@@ -282,8 +275,6 @@ class WebformMetadataDate extends FormElement {
       ],
     ];
 
-
-
     if (!isset($element['#showfreeformalways']) || (isset($element['#showfreeformalways']) && $element['#showfreeformalways'] == FALSE )) {
       $element['date_free']['#states'] = [
         'invisible' => [
@@ -294,22 +285,12 @@ class WebformMetadataDate extends FormElement {
       ];
     }
 
-
     // Don't require the main element.
     $element['#required'] = FALSE;
-
-    // Hide title and description from being display.
-    //$element['#title_display'] = 'invisible';
-    //$element['#description_display'] = 'invisible';
 
     // Remove properties that are being applied to the sub elements.
     unset(
       $element['#maxlength'],
-      $element['#attributes'],
-      $element['#description'],
-      $element['#help'],
-      $element['#help_title'],
-      $element['#help_display']
     );
 
 
@@ -361,12 +342,6 @@ class WebformMetadataDate extends FormElement {
         $makeshift_element['#parents'] = $multi_item_parents;
         $form_state->setValueForElement($makeshift_element, NULL);
       }
-      /*$valuetoset = [
-        'date_free' => $metadatadate_element['date_free']['#value'],
-        'date_from' => $metadatadate_element['date_from']['#value'],
-        'date_to' => $metadatadate_element['date_to']['#value'],
-        'date_type' => $metadatadate_element['date_type']['#value'],
-        ]; */
     } else {
       if (!empty($element['#value'])) {
         $value = $form_state->getValue($element['#parents'], []);
@@ -380,6 +355,18 @@ class WebformMetadataDate extends FormElement {
           $element['#value'] = $value;
         }
         $form_state->setValueForElement($element, $element['#value']);
+      }
+    }
+
+    // Perform edtf validation on freeform date if so configured.
+    if(!empty($metadatadate_element['#edtf_validateme']) && !empty($element['#value']['date_free'])) {
+      $validator = EdtfFactory::newValidator();
+      if (!$validator->isValidEdtf($element['#value']['date_free'])) {
+        $form_state->setError($element['date_free'],
+          t('The extended date time format string for the @name field is invalid.',
+            [
+              '@name' => $element['#title'],
+            ]));
       }
     }
   }

--- a/src/Plugin/WebformElement/WebformMetadataDate.php
+++ b/src/Plugin/WebformElement/WebformMetadataDate.php
@@ -58,6 +58,7 @@ class WebformMetadataDate extends MetadataDateBase {
         'step' => '',
         'size' => '',
         'input_hide' => FALSE,
+        'edtf_validateme' => FALSE,
       ] + parent::defineDefaultProperties()
       + $this->defineDefaultMultipleProperties();
   }
@@ -119,6 +120,19 @@ class WebformMetadataDate extends MetadataDateBase {
         'If checked both Point and Range modes will also allow a non validated free form input'
       ),
       '#return_value' => TRUE,
+    ];
+    $form['date']['edtf_validateme'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Validate freeform date as EDTF'),
+      '#description' => $this->t(
+        'Option to validate the freeform date as extended date/time format date (EDTF). See <a href="https://www.loc.gov/standards/datetime/">here</a>'
+      ),
+      '#return_value' => TRUE,
+      '#states' => [
+        'visible' => [
+          ':input[name="properties[showfreeformalways]"]' => ['checked' => TRUE],
+        ],
+      ],
     ];
     $form['date']['datepicker'] = [
       '#type' => 'checkbox',


### PR DESCRIPTION
* ISSUE-102 --- initial work in progress on EDTF date field configuration and validation

* Born-Digital 1.0.0-RC1 --- reset composer requires of strawberryfield and webform_strawberryfield modules to 1.0.0-RC1

* BD 1.0.0-RC1 --- fix bug where \WebformMetadataDate::presave saved single value fields as if they were multi-value, thus malforming the json and preventing the values from being reloaded to the webform upon webform reload.

* ISSUE-102 --- Changes to utilize EDTF\EdtfFactory for edtf validation
* simplified webformmetadatadate configuration - we only enable or disable edtf validation. This is because the new EDTF library does not report back detailed validation errors - only true or false
* adapted \WebformMetadataDate::validateMetadataDates to the new validation function

TODO: when the value does not validate, the error message is not targeted to the free text sub-element in the metadata date element

* ISSUE-102 --- deleted EDTFUtils.php

* ISSUE-102 --- fixed composer.json for strawberryfield and format_strawberryfield versions

* Fix missing Validation Message and Fixes wrapper

@patdunlavey hope this works out(way more than 2 hours, sorry I'm the worst!). Can you test with a submission/saving/reloading too?
 Error shows well now, but I noticed that normal Date validation (point/range) depends a lot on JS right now so we may to iterate in a separate ISSUE of Form only validation or maybe we can reuse EDTF for this too? Given that ISO 8601 should pass an EDTF validation? Sorry I have only questions here.

WE may also want to have a few extra settings (for the element) so users can setup per subfield help/descriptions/etc?

Co-authored-by: Pat Dunlavey <pat@born-digital.com>
Co-authored-by: Diego Pino Navarro <DiegoPino@users.noreply.github.com>